### PR TITLE
Implement find users by tag

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -260,7 +260,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* * *`  | user                                       | add a new person                  |                                                                        |
 | `* * *`  | user                                       | delete a person                   | remove entries that I no longer need                                   |
 | `* * *`  | user                                       | find a person by name             | locate details of persons without having to go through the entire list |
-| `* * *`  | user                                       | filter contacts                   | minimize chance of sending emails to the wrong recipient               |
+| `* * *`  | user                                       | filter contacts by tags           | minimize chance of sending emails to the wrong recipient               |
 | `* * *`  | user                                       | specify preferred mode of contact | maximize chance of recipient seeing the information                    |
 | `* * *`  | user                                       | blacklist a contact               | reduce dissemination of information to people who do not want it       |
 | `* *`    | user                                       | hide private contact details      | minimize chance of someone else seeing them by accident                |
@@ -296,8 +296,25 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
     
-**Use case: Filter contacts**
+**Use case: Filter contacts by tags**
 
+**MSS**
+1. User requests to list contacts
+2. SpamEZ shows a list of contacts
+3. User requests to find the contacts using name and/or tags
+4. SpamEZ returns a filtered list of contacts
+
+   Use case ends.
+
+**Extensions**
+* 2a. The list is empty.
+
+  Use case ends.
+
+* 3a. No keywords are given or invalid syntax.
+    * 3a1. SpamEZ shows an error message.
+    
+      Use case resumes at step 2.
 
 **Use case: Specify a preferred mode of contact for a contact**
 
@@ -396,3 +413,25 @@ testers are expected to do more *exploratory* testing.
    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
 
 1. _{ more test cases …​ }_
+
+### Filtering the contacts
+
+1. Filter the list of contacts based on the keywords provided.
+
+    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
+    
+    1. Test case: `find n/Alex Bernice` <br>
+       Expected: A list of contacts whose name contains `Alex` **or** `Bernice`. The filter is case-insensitive, so `Alex` will match with `aLeX` too, for instance.
+       
+    1. Test case: `find t/friends NEIGHBOUR` <br>
+       Expected: A list of contacts whose tags contain `friends` **or** `NEIGHBOUR`.
+ 
+    1. Test case: `find n/Alex Bernice t/friends neighbour` <br>
+       Expected: A list of contacts whose name contains `Alex` or `Bernice` **and** tags contains `friends` or `neighbour`.
+       
+    1. Test case: `find` <br>
+       Expected: No filtering is done, and the original list is presented. Error details shown in the status message.
+       
+    1. Other incorrect find commands to try: `find n/`, `find t/`, `...` <br>
+       Expected: Similar to previous.
+       

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -260,7 +260,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* * *`  | user                                       | add a new person                  |                                                                        |
 | `* * *`  | user                                       | delete a person                   | remove entries that I no longer need                                   |
 | `* * *`  | user                                       | find a person by name             | locate details of persons without having to go through the entire list |
-| `* * *`  | user                                       | filter contacts by tags           | minimize chance of sending emails to the wrong recipient               |
+| `* * *`  | user                                       | filter contacts                   | minimize chance of sending emails to the wrong recipient               |
 | `* * *`  | user                                       | specify preferred mode of contact | maximize chance of recipient seeing the information                    |
 | `* * *`  | user                                       | blacklist a contact               | reduce dissemination of information to people who do not want it       |
 | `* *`    | user                                       | hide private contact details      | minimize chance of someone else seeing them by accident                |
@@ -296,25 +296,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
     
-**Use case: Filter contacts by tags**
+**Use case: Filter contacts**
 
-**MSS**
-1. User requests to list contacts
-2. SpamEZ shows a list of contacts
-3. User requests to find the contacts using name and/or tags
-4. SpamEZ returns a filtered list of contacts
-
-   Use case ends.
-
-**Extensions**
-* 2a. The list is empty.
-
-  Use case ends.
-
-* 3a. No keywords are given or invalid syntax.
-    * 3a1. SpamEZ shows an error message.
-    
-      Use case resumes at step 2.
 
 **Use case: Specify a preferred mode of contact for a contact**
 
@@ -413,25 +396,3 @@ testers are expected to do more *exploratory* testing.
    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
 
 1. _{ more test cases …​ }_
-
-### Filtering the contacts
-
-1. Filter the list of contacts based on the keywords provided.
-
-    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
-    
-    1. Test case: `find n/Alex Bernice` <br>
-       Expected: A list of contacts whose name contains `Alex` **or** `Bernice`. The filter is case-insensitive, so `Alex` will match with `aLeX` too, for instance.
-       
-    1. Test case: `find t/friends NEIGHBOUR` <br>
-       Expected: A list of contacts whose tags contain `friends` **or** `NEIGHBOUR`.
- 
-    1. Test case: `find n/Alex Bernice t/friends neighbour` <br>
-       Expected: A list of contacts whose name contains `Alex` or `Bernice` **and** tags contains `friends` or `neighbour`.
-       
-    1. Test case: `find` <br>
-       Expected: No filtering is done, and the original list is presented. Error details shown in the status message.
-       
-    1. Other incorrect find commands to try: `find n/`, `find t/`, `...` <br>
-       Expected: Similar to previous.
-       

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,18 +118,19 @@ Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-### Locating persons by name: `find`
+### Locating persons by name and/or tag: `find`
 
-Finds persons whose names contain any of the given keywords.
+Finds persons whose names and/or tags contain any of the given keywords.
 
-Format: `find KEYWORD [MORE_KEYWORDS]`
+Format: `find [n/NAME_KEYWORDS] [t/TAG_KEYWORDS]`
 
+* At least one of `[n/NAME_KEYWORDS]` or `[t/TAG_KEYWORDS]` must be included as the parameters.
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
+* Only the name and tags are searched.
 * Only full words will be matched e.g. `Han` will not match `Hans`
-* Persons matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* Persons matching at least one keyword of each provided attribute will be returned.
+  e.g. `n/Hans Bo` will return `Hans Gruber`, `Bo Yang`, `Bo Hans`, while `n/Hans Bo t/friends` will only return `Hans Gruber` and `Bo Yang` if only `Hans Gruber` and `Bo Yang` are tagged with `friends`. 
 
 Examples:
 * `find John` returns `john` and `John Doe`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -133,9 +133,10 @@ Format: `find [n/NAME_KEYWORDS] [t/TAG_KEYWORDS]`
   e.g. `n/Hans Bo` will return `Hans Gruber`, `Bo Yang`, `Bo Hans`, while `n/Hans Bo t/friends` will only return `Hans Gruber` and `Bo Yang` if only `Hans Gruber` and `Bo Yang` are tagged with `friends`. 
 
 Examples:
-* `find John` returns `john` and `John Doe`
-* `find alex david` returns `Alex Yeoh`, `David Li`<br>
+* `find n/John` returns `john` and `John Doe`
+* `find n/alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
+* `find n/alex david t/family` returns `David Li`
 
 ### Deleting a person : `delete`
 
@@ -222,7 +223,7 @@ Action | Format, Examples
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Find** | `find [n/NAME_KEYWORDS] [t/TAG_KEYWORDS]`<br> e.g., `find n/James Jake t/classmates`
 **Tag** | `tag n/NAME t/TAG`<br> e.g., `tag n/Jane Bo t/Student`
 **Name** | `name INDEX [n/NAME]`<br> e.g., `name 3 [n/Jo]`
 **Blist** | `blist INDEX`<br> e.g., `blist 3`

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,17 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
+import seedu.address.model.person.ReturnTruePredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -14,21 +21,39 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names and/or"
+            + "tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: "
+            + PREFIX_NAME + "NAME_KEYWORD [MORE_NAME_KEYWORDS]... "
+            + PREFIX_TAG + "TAG_KEYWORD [MORE_TAG_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "alice bob charlie "
+            + PREFIX_TAG + "friends neighbours";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> namePredicate;
+    private final Predicate<Person> tagPredicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    /**
+     * Creates a FindCommand to find the {@code Person}s with matching keywords.
+     * @param namePredicate Predicate made up of names to match.
+     * @param tagPredicate Predicate made up of tags to match.
+     */
+    public FindCommand(Predicate<Person> namePredicate,
+                       Predicate<Person> tagPredicate) {
+        assert (namePredicate instanceof NameContainsKeywordsPredicate
+                || namePredicate instanceof ReturnTruePredicate);
+        assert (tagPredicate instanceof PersonTagContainsKeywordsPredicate
+                || tagPredicate instanceof ReturnTruePredicate);
+
+        this.namePredicate = namePredicate;
+        this.tagPredicate = tagPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        model.updateFilteredPersonList(namePredicate.and(tagPredicate));
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -37,6 +62,7 @@ public class FindCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && namePredicate.equals(((FindCommand) other).namePredicate)
+                && tagPredicate.equals(((FindCommand) other).tagPredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -35,7 +35,11 @@ public class FindCommandParser implements Parser<FindCommand> {
         Optional<String> nameKeywords = argMultimap.getValue(PREFIX_NAME);
         Optional<String> tagKeywords = argMultimap.getValue(PREFIX_TAG);
 
-        if (nameKeywords.isEmpty() && tagKeywords.isEmpty()) {
+        boolean bothEmpty = nameKeywords.isEmpty() && tagKeywords.isEmpty();
+        boolean emptyNameKeywords = nameKeywords.isPresent() && nameKeywords.get().equals("");
+        boolean emptyTagKeywords = tagKeywords.isPresent() && tagKeywords.get().equals("");
+
+        if (bothEmpty || emptyNameKeywords || emptyTagKeywords) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
+import seedu.address.model.person.ReturnTruePredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +26,29 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG);
+
+        Predicate<Person> namePredicate = new ReturnTruePredicate();
+        Predicate<Person> tagPredicate = new ReturnTruePredicate();
+
+        Optional<String> nameKeywords = argMultimap.getValue(PREFIX_NAME);
+        Optional<String> tagKeywords = argMultimap.getValue(PREFIX_TAG);
+
+        if (nameKeywords.isEmpty() && tagKeywords.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (nameKeywords.isPresent()) {
+            String[] names = nameKeywords.get().split("\\s+");
+            namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(names));
+        }
+        if (tagKeywords.isPresent()) {
+            String[] tags = tagKeywords.get().split("\\s+");
+            tagPredicate = new PersonTagContainsKeywordsPredicate(Arrays.asList(tags));
+        }
+        return new FindCommand(namePredicate, tagPredicate);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/PersonTagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonTagContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person} has one of his/her {@code Tag}s matches any of the keywords given.
+ */
+public class PersonTagContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PersonTagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getTags().stream().anyMatch(
+                    tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof PersonTagContainsKeywordsPredicate
+                && keywords.equals(((PersonTagContainsKeywordsPredicate) other).keywords));
+    }
+}

--- a/src/main/java/seedu/address/model/person/ReturnTruePredicate.java
+++ b/src/main/java/seedu/address/model/person/ReturnTruePredicate.java
@@ -1,0 +1,18 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+/**
+ * A dummy predicate that returns true all the time.
+ */
+public class ReturnTruePredicate implements Predicate<Person> {
+    @Override
+    public boolean test(Person person) {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ReturnTruePredicate;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,7 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -19,6 +23,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
+import seedu.address.model.person.ReturnTruePredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -26,6 +32,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private ReturnTruePredicate returnTruePredicate = new ReturnTruePredicate();
 
     @Test
     public void equals() {
@@ -34,15 +41,34 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        PersonTagContainsKeywordsPredicate firstTagPredicate =
+                new PersonTagContainsKeywordsPredicate(Collections.singletonList("tagOne"));
+        PersonTagContainsKeywordsPredicate secondTagPredicate =
+                new PersonTagContainsKeywordsPredicate(Collections.singletonList("tagTwo"));
+
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, returnTruePredicate);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, returnTruePredicate);
+
+        FindCommand findThirdCommand = new FindCommand(returnTruePredicate, firstTagPredicate);
+        FindCommand findFourthCommand = new FindCommand(returnTruePredicate, secondTagPredicate);
+
+        FindCommand findFifthCommand = new FindCommand(firstPredicate, firstTagPredicate);
+        FindCommand findSixthCommand = new FindCommand(secondPredicate, secondTagPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(findThirdCommand.equals(findThirdCommand));
+        assertTrue(findFifthCommand.equals(findFifthCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, returnTruePredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        FindCommand findFourthCommandCopy = new FindCommand(returnTruePredicate, secondTagPredicate);
+        assertTrue(findFourthCommand.equals(findFourthCommandCopy));
+
+        FindCommand findSixthCommandCopy = new FindCommand(secondPredicate, secondTagPredicate);
+        assertTrue(findSixthCommand.equals(findSixthCommandCopy));
 
         // different types -> returns false
         assertFalse(findFirstCommand.equals(1));
@@ -52,26 +78,58 @@ public class FindCommandTest {
 
         // different person -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(findThirdCommand.equals(findFourthCommand));
+        assertFalse(findFifthCommand.equals(findSixthCommand));
+
+        assertFalse(findFirstCommand.equals(findThirdCommand));
+        assertFalse(findFirstCommand.equals(findFifthCommand));
+        assertFalse(findThirdCommand.equals(findFifthCommand));
     }
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        PersonTagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(" ");
+        FindCommand command = new FindCommand(predicate, tagPredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
+    public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        FindCommand command = new FindCommand(predicate, returnTruePredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_multiplePersonsFound() {
+        model.addPerson(BOB);
+        expectedModel.addPerson(BOB);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        PersonTagContainsKeywordsPredicate predicate = prepareTagPredicate("friends husband");
+        FindCommand command = new FindCommand(returnTruePredicate, predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL, BOB), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleNameAndTagKeywords_multiplePersonsFound() {
+        model.addPerson(BOB);
+        expectedModel.addPerson(BOB);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        NameContainsKeywordsPredicate namePredicate = preparePredicate("Pauline Elle Choo");
+        PersonTagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friends husband");
+        FindCommand command = new FindCommand(namePredicate, tagPredicate);
+        expectedModel.updateFilteredPersonList(namePredicate.and(tagPredicate));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BOB), model.getFilteredPersonList());
     }
 
     /**
@@ -79,5 +137,12 @@ public class FindCommandTest {
      */
     private NameContainsKeywordsPredicate preparePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code PersonTagContainsKeywordsPredicate}.
+     */
+    private PersonTagContainsKeywordsPredicate prepareTagPredicate(String userInput) {
+        return new PersonTagContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -25,6 +27,8 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
+import seedu.address.model.person.ReturnTruePredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -32,6 +36,7 @@ import seedu.address.testutil.PersonUtil;
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
+    private ReturnTruePredicate returnTruePredicate = new ReturnTruePredicate();
 
     @Test
     public void parseCommand_add() throws Exception {
@@ -70,10 +75,15 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
+        List<String> tagKeywords = Arrays.asList("tagOne", "tagTwo");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " "
+                        + PREFIX_NAME + nameKeywords.stream().collect(Collectors.joining(" ")) + " "
+                        + PREFIX_TAG + tagKeywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
+                new PersonTagContainsKeywordsPredicate(tagKeywords)),
+                command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -10,10 +12,13 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
+import seedu.address.model.person.ReturnTruePredicate;
 
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();
+    private ReturnTruePredicate returnTruePredicate = new ReturnTruePredicate();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
@@ -21,14 +26,37 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")), returnTruePredicate);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        FindCommand expectedFindCommand =
+                new FindCommand(returnTruePredicate,
+                        new PersonTagContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, " " + PREFIX_TAG + "Alice Bob", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " " + PREFIX_TAG + " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validNameAndTagArgs_returnsFindCommand() {
+        FindCommand expectedFindCommand =
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        new PersonTagContainsKeywordsPredicate(Arrays.asList("tagOne", "tagTwo")));
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob " + PREFIX_TAG + "tagOne tagTwo",
+                expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t " + PREFIX_TAG + "tagOne \t tagTwo\n\t",
+                expectedFindCommand);
+    }
 }


### PR DESCRIPTION
Fixes #5 

Enhance the `find` command by adding the support to find contacts using both names and tags. To accommodate for this change, two new predicate classes `ReturnTruePredicate` and `PersonTagContainsKeywordsPredicate` were introduced. The `parse` method in `FindCommandParser` was rewritten too.

The `FindCommand` class now receives two `Predicate` objects instead of only `NameContainsKeywordsPredicate`. However, as reflected in the `assert` statements in the constructor, the first parameter still receives a `NameContainsKeywordsPredicate`, while the second parameter receives a `PersonTagContainsKeywordsPredicate`. Both can receive a `ReturnTruePredicate`.

Updated JUnit tests and included some new ones for new parameters supported by `find` command. User guide is also updated accordingly.