### PR TITLE
Add MassDelete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,6 +153,18 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the contacts list.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
+###Deleting multiple contacts simultaneously : `massdelete`
+
+Deletes all contacts within the specified index range.
+
+Format: `massdelete start/INDEX end/INDEX`
+* The index refers to the index number shown in the displayed person list.
+* Both the Start Index and End Index must be a positive integer 1,2,3, ...
+* Start Index < End Index and End Index cannot be larger than the number of contacts in the list.
+
+Example:
+`massdelete start/2 end/41`
+
 ### Adding tags to a contact : `tag`
 
 Labels a contact based on his or her attributes.

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -31,6 +31,10 @@ public class Index {
         return zeroBasedIndex + 1;
     }
 
+    public static int getInterval(Index startIndex, Index endIndex) {
+        return endIndex.zeroBasedIndex - startIndex.zeroBasedIndex;
+    }
+
     /**
      * Creates a new {@code Index} using a zero-based index.
      */

--- a/src/main/java/seedu/address/logic/commands/MassDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MassDeleteCommand.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.index.Index.getInterval;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Deletes all contacts within a specified index range(inclusive).
+ */
+public class MassDeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "massdelete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes all contacts within a specified index range(inclusive).\n"
+            + "Parameters: "
+            + PREFIX_START_INDEX + "STARTINDEX "
+            + PREFIX_END_INDEX + "ENDINDEX\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_START_INDEX + "1 " + PREFIX_END_INDEX + "21";
+
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Successfully deleted all contacts"
+            + " within the specified range";
+    public static final String MESSAGE_INVALID_START_INDEX = "Start index must be positive";
+    public static final String MESSAGE_INVALID_END_INDEX = "End index must be larger than start index but "
+            + "smaller than the number of people in the contact list.";
+
+    private final Index startIndex;
+    private final Index endIndex;
+
+    /**
+     * Creates a MassDeleteCommand to delete all contacts within the specified index range.
+     */
+    public MassDeleteCommand(Index startIndex, Index endIndex) {
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (endIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_END_INDEX);
+        }
+        int intervalToDelete = getInterval(startIndex, endIndex);
+        for (int i = 0; i <= intervalToDelete; i++) {
+            Person personToDelete = lastShownList.get(startIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+        }
+        return new CommandResult(MESSAGE_DELETE_PERSON_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true; // short circuit if same object
+        }
+        if (other instanceof MassDeleteCommand) {
+            return startIndex.equals(((MassDeleteCommand) other).startIndex)
+                    && endIndex.equals(((MassDeleteCommand) other).endIndex);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -35,7 +35,7 @@ public class RemarkCommand extends Command {
     private final Remark remark;
 
     /**
-     * Add or replace the remark of an existing person in the address book.
+     * Creates a remark command to add or replace the remark of an existing person in the address book.
      */
     public RemarkCommand(Index index, Remark remark) {
         requireAllNonNull(index, remark);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MassDeleteCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -58,6 +59,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case MassDeleteCommand.COMMAND_WORD:
+            return new MassDeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,4 +15,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_SORT_CRITERIA = new Prefix("c/");
     public static final Prefix PREFIX_DIRECTION = new Prefix("d/");
+    public static final Prefix PREFIX_START_INDEX = new Prefix("start/");
+    public static final Prefix PREFIX_END_INDEX = new Prefix("end/");
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,5 +25,4 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/MassDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MassDeleteCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_INDEX;
+
+import java.util.NoSuchElementException;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MassDeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class MassDeleteCommandParser implements Parser<MassDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MassDeleteCommand
+     * and returns a MassDeleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MassDeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_START_INDEX, PREFIX_END_INDEX);
+        try {
+            Index startIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_START_INDEX).get());
+            Index endIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_END_INDEX).get());
+            return new MassDeleteCommand(startIndex, endIndex);
+        } catch (NoSuchElementException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MassDeleteCommand.MESSAGE_USAGE), ive);
+        } catch (ParseException parseException) {
+            throw new ParseException(String.format(MassDeleteCommand.MESSAGE_INVALID_START_INDEX,
+                    MassDeleteCommand.MESSAGE_USAGE), parseException);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #38

Add a new `MassDeleteCommand` class to handle mass delete operations, along with a corresponding `MassDeleteParser` class. `MassDeleteCommand` command is separate from `DeleteCommand` and neither class depend on each other.

