### PR TITLE
Implement traversing command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -209,6 +209,10 @@ CRITERIA | Description | Example
 --------|------------------|------
 **name** | Sort by name in alphabetical order| sort c/name d/descending
 
+### Review previous commands
+Users can view the commands they have inserted previously using up and down arrow keys.
+To re-execute the command, users simply need to press enter.
+
 ### Exiting the program : `exit`
 
 Exits the program.

--- a/src/main/java/seedu/address/logic/commandlist/CommandList.java
+++ b/src/main/java/seedu/address/logic/commandlist/CommandList.java
@@ -8,7 +8,7 @@ package seedu.address.logic.commandlist;
 public class CommandList {
     private CommandNode headPointer = new CommandNode("");
     private CommandNode tailPointer = new CommandNode("");
-    private CommandNode cursor = new CommandNode("");
+    private CommandNode cursor = tailPointer;
 
     private int size = 0;
 
@@ -20,12 +20,17 @@ public class CommandList {
         CommandNode tempNode = new CommandNode(command);
         if (size == 0) {
             headPointer = tempNode;
+            tempNode.nextNode = tailPointer;
+            tailPointer.prevNode = tempNode;
         } else {
-            tailPointer.nextNode = tempNode;
-            tempNode.prevNode = tailPointer;
+            CommandNode lastCommand = tailPointer.prevNode;
+            lastCommand.nextNode = tempNode;
+            tempNode.prevNode = lastCommand;
+
+            tailPointer.prevNode = tempNode;
+            tempNode.nextNode = tailPointer;
         }
-        tailPointer = tempNode;
-        cursor = tempNode;
+        cursor = tailPointer;
         size++;
     }
 
@@ -37,7 +42,7 @@ public class CommandList {
      * if there is no previous node.
      */
     public String moveDown() {
-        if (cursor.nextNode != null) {
+        if (cursor.nextNode != tailPointer && cursor.nextNode != null) {
             cursor = cursor.nextNode;
         }
         return cursor.command;
@@ -66,7 +71,7 @@ public class CommandList {
     public String toString() {
         CommandNode printingCursor = headPointer;
         StringBuilder result = new StringBuilder("[");
-        while (printingCursor != null) {
+        while (printingCursor != tailPointer) {
             result.append(printingCursor.command);
             result.append(", ");
             printingCursor = printingCursor.nextNode;

--- a/src/main/java/seedu/address/logic/commandlist/CommandList.java
+++ b/src/main/java/seedu/address/logic/commandlist/CommandList.java
@@ -80,7 +80,7 @@ public class CommandList {
      * Returns the size of the list.
      * @return The size of the list.
      */
-    public int getSize(){
+    public int getSize() {
         return this.size;
     }
 

--- a/src/main/java/seedu/address/logic/commandlist/CommandList.java
+++ b/src/main/java/seedu/address/logic/commandlist/CommandList.java
@@ -1,0 +1,100 @@
+package seedu.address.logic.commandlist;
+
+/**
+ * Class to hold the commands inputted by users. It is modelled as a linked list
+ * because users will primarily use arrow keys to traverse through the commands
+ * they have inputted.
+ */
+public class CommandList {
+    private CommandNode headPointer = new CommandNode("");
+    private CommandNode tailPointer = new CommandNode("");
+    private CommandNode cursor = new CommandNode("");
+
+    private int size = 0;
+
+    /**
+     * Adds a command into the list.
+     * @param command Command to be added.
+     */
+    public void addCommand(String command) {
+        CommandNode tempNode = new CommandNode(command);
+        if (size == 0) {
+            headPointer = tempNode;
+        } else {
+            tailPointer.nextNode = tempNode;
+            tempNode.prevNode = tailPointer;
+        }
+        tailPointer = tempNode;
+        cursor = tempNode;
+        size++;
+    }
+
+    /**
+     * Moves the pointer to previous node in the list and returns the command stored.
+     * If the pointer is at the previous node at the time of calling, command stored
+     * in the first node is returned.
+     * @return Command stored in the previous node, or command stored in the head node
+     * if there is no previous node.
+     */
+    public String moveDown() {
+        if (cursor.nextNode != null) {
+            cursor = cursor.nextNode;
+        }
+        return cursor.command;
+    }
+
+    /**
+     * Moves the pointer to next node in the list and returns the command stored.
+     * If the pointer is at the last node at the time of calling, the command
+     * stored in the last node is returned.
+     * @return Command stored in the next node, or command stored in the tail node if the
+     * pointer is at the last node.
+     */
+    public String moveUp() {
+        if (cursor.prevNode != null) {
+            cursor = cursor.prevNode;
+        }
+        return cursor.command;
+    }
+
+    // The following methods are solely for testing purposes.
+
+    /**
+     * Returns a string representation of the list.
+     * @return A string representation of the list.
+     */
+    public String toString() {
+        CommandNode printingCursor = headPointer;
+        StringBuilder result = new StringBuilder("[");
+        while (printingCursor != null) {
+            result.append(printingCursor.command);
+            result.append(", ");
+            printingCursor = printingCursor.nextNode;
+        }
+        result = new StringBuilder(result.substring(0, result.length() - 2));
+        result.append("]");
+        return result.toString();
+    }
+
+    /**
+     * Returns the size of the list.
+     * @return The size of the list.
+     */
+    public int getSize(){
+        return this.size;
+    }
+
+
+    private static class CommandNode {
+        private final String command;
+        private CommandNode prevNode;
+        private CommandNode nextNode;
+
+        public CommandNode(String command) {
+            this.command = command;
+            this.prevNode = null;
+            this.nextNode = null;
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,7 +3,9 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
+import seedu.address.logic.commandlist.CommandList;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,6 +20,8 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandExecutor commandExecutor;
 
+    private final CommandList commandList = new CommandList();
+
     @FXML
     private TextField commandTextField;
 
@@ -29,6 +33,13 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.UP) {
+                handleUpPressed();
+            } else if (event.getCode() == KeyCode.DOWN) {
+                handleDownPressed();
+            }
+        });
     }
 
     /**
@@ -40,6 +51,7 @@ public class CommandBox extends UiPart<Region> {
         if (commandText.equals("")) {
             return;
         }
+        commandList.addCommand(commandText);
 
         try {
             commandExecutor.execute(commandText);
@@ -47,6 +59,14 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
+    }
+
+    private void handleUpPressed() {
+        commandTextField.setText(commandList.moveUp());
+    }
+
+    private void handleDownPressed() {
+        commandTextField.setText(commandList.moveDown());
     }
 
     /**

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1">
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..." />
 </StackPane>
-

--- a/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
+++ b/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
@@ -31,8 +31,8 @@ public class CommandListTest {
         commandList.addCommand("ghi");
 
 
+        assertEquals("ghi", commandList.moveUp());
         assertEquals("def", commandList.moveUp());
-        assertEquals("abc", commandList.moveUp());
         assertEquals("abc", commandList.moveUp());
         assertEquals("abc", commandList.moveUp());
     }
@@ -43,7 +43,7 @@ public class CommandListTest {
         commandList.addCommand("def");
         commandList.addCommand("ghi");
 
-        for (int i = 0; i < commandList.getSize(); i++) {
+        for (int i = 0; i < commandList.getSize() + 1; i++) {
             commandList.moveUp();
         }
 

--- a/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
+++ b/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commandlist;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CommandListTest {
+
+    CommandList commandList;
+
+    @BeforeEach
+    public void clear() {
+        commandList = new CommandList();
+    }
+
+    @Test
+    public void addCommand_allArgs_success() {
+        commandList.addCommand("abc");
+        commandList.addCommand("def");
+        commandList.addCommand("");
+        commandList.addCommand("ghi");
+
+        assertEquals("[abc, def, , ghi]", commandList.toString());
+    }
+
+    @Test
+    public void moveUp_nonEmptyList_success() {
+        commandList.addCommand("abc");
+        commandList.addCommand("def");
+        commandList.addCommand("ghi");
+
+
+        assertEquals("def", commandList.moveUp());
+        assertEquals("abc", commandList.moveUp());
+        assertEquals("abc", commandList.moveUp());
+        assertEquals("abc", commandList.moveUp());
+    }
+
+    @Test
+    public void moveDown_nonEmptyList_success() {
+        commandList.addCommand("abc");
+        commandList.addCommand("def");
+        commandList.addCommand("ghi");
+
+        for (int i = 0; i < commandList.getSize(); i++) {
+            commandList.moveUp();
+        }
+
+        assertEquals("def", commandList.moveDown());
+        assertEquals("ghi", commandList.moveDown());
+        assertEquals("ghi", commandList.moveDown());
+        assertEquals("ghi", commandList.moveDown());
+    }
+
+    @Test
+    public void moveUp_emptyList_success() {
+        assertEquals("", commandList.moveUp());
+    }
+
+    @Test
+    public void moveDown_emptyList_success() {
+        assertEquals("", commandList.moveDown());
+    }
+}

--- a/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
+++ b/src/test/java/seedu/address/logic/commandlist/CommandListTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 public class CommandListTest {
 
-    CommandList commandList;
+    private CommandList commandList;
 
     @BeforeEach
     public void clear() {


### PR DESCRIPTION
Fixes #35.

Implement a feature where users can traverse through the list of commands they have inputted. `CommandList` class is introduced to help with the implementation.

JUnit tests are added, but to primarily test out the functionalities in `CommandList` works.