### PR TITLE
Implement find people by address

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -8,6 +9,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
@@ -29,10 +31,12 @@ public class FindCommand extends Command {
             + PREFIX_TAG + "TAG_KEYWORD [MORE_TAG_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "alice bob charlie "
-            + PREFIX_TAG + "friends neighbours";
+            + PREFIX_TAG + "friends neighbours"
+            + PREFIX_ADDRESS + "Singapore";
 
     private final Predicate<Person> namePredicate;
     private final Predicate<Person> tagPredicate;
+    private final Predicate<Person> addressPredicate;
 
     /**
      * Creates a FindCommand to find the {@code Person}s with matching keywords.
@@ -40,20 +44,24 @@ public class FindCommand extends Command {
      * @param tagPredicate Predicate made up of tags to match.
      */
     public FindCommand(Predicate<Person> namePredicate,
-                       Predicate<Person> tagPredicate) {
+                       Predicate<Person> tagPredicate,
+                       Predicate<Person> addressPredicate) {
         assert (namePredicate instanceof NameContainsKeywordsPredicate
                 || namePredicate instanceof ReturnTruePredicate);
         assert (tagPredicate instanceof PersonTagContainsKeywordsPredicate
                 || tagPredicate instanceof ReturnTruePredicate);
+        assert (addressPredicate instanceof AddressContainsKeywordsPredicate
+                || addressPredicate instanceof ReturnTruePredicate);
 
         this.namePredicate = namePredicate;
         this.tagPredicate = tagPredicate;
+        this.addressPredicate = addressPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(namePredicate.and(tagPredicate));
+        model.updateFilteredPersonList(namePredicate.and(tagPredicate).and(addressPredicate));
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
@@ -63,6 +71,7 @@ public class FindCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
                 && namePredicate.equals(((FindCommand) other).namePredicate)
-                && tagPredicate.equals(((FindCommand) other).tagPredicate)); // state check
+                && tagPredicate.equals(((FindCommand) other).tagPredicate)
+                && addressPredicate.equals(((FindCommand) other).addressPredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -10,6 +11,7 @@ import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
@@ -27,19 +29,22 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_ADDRESS);
 
         Predicate<Person> namePredicate = new ReturnTruePredicate();
         Predicate<Person> tagPredicate = new ReturnTruePredicate();
+        Predicate<Person> addressPredicate = new ReturnTruePredicate();
 
         Optional<String> nameKeywords = argMultimap.getValue(PREFIX_NAME);
         Optional<String> tagKeywords = argMultimap.getValue(PREFIX_TAG);
+        Optional<String> addressKeywords = argMultimap.getValue(PREFIX_ADDRESS);
 
-        boolean bothEmpty = nameKeywords.isEmpty() && tagKeywords.isEmpty();
+        boolean allEmpty = nameKeywords.isEmpty() && tagKeywords.isEmpty() && addressKeywords.isEmpty();
         boolean emptyNameKeywords = nameKeywords.isPresent() && nameKeywords.get().equals("");
         boolean emptyTagKeywords = tagKeywords.isPresent() && tagKeywords.get().equals("");
+        boolean emptyAddressKeywords = addressKeywords.isPresent() && addressKeywords.get().equals("");
 
-        if (bothEmpty || emptyNameKeywords || emptyTagKeywords) {
+        if (allEmpty || emptyNameKeywords || emptyTagKeywords || emptyAddressKeywords) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -52,7 +57,11 @@ public class FindCommandParser implements Parser<FindCommand> {
             String[] tags = tagKeywords.get().split("\\s+");
             tagPredicate = new PersonTagContainsKeywordsPredicate(Arrays.asList(tags));
         }
-        return new FindCommand(namePredicate, tagPredicate);
+        if (addressKeywords.isPresent()) {
+            String[] address = addressKeywords.get().split("\\s+");
+            addressPredicate = new AddressContainsKeywordsPredicate(Arrays.asList(address));
+        }
+        return new FindCommand(namePredicate, tagPredicate, addressPredicate);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof AddressContainsKeywordsPredicate
+                && keywords.equals(((AddressContainsKeywordsPredicate) other).keywords));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.PersonTagContainsKeywordsPredicate;
 import seedu.address.model.person.ReturnTruePredicate;
@@ -46,14 +47,20 @@ public class FindCommandTest {
         PersonTagContainsKeywordsPredicate secondTagPredicate =
                 new PersonTagContainsKeywordsPredicate(Collections.singletonList("tagTwo"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate, returnTruePredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate, returnTruePredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate,
+                returnTruePredicate, returnTruePredicate);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate,
+                returnTruePredicate, returnTruePredicate);
 
-        FindCommand findThirdCommand = new FindCommand(returnTruePredicate, firstTagPredicate);
-        FindCommand findFourthCommand = new FindCommand(returnTruePredicate, secondTagPredicate);
+        FindCommand findThirdCommand = new FindCommand(returnTruePredicate,
+                firstTagPredicate, returnTruePredicate);
+        FindCommand findFourthCommand = new FindCommand(returnTruePredicate,
+                secondTagPredicate, returnTruePredicate);
 
-        FindCommand findFifthCommand = new FindCommand(firstPredicate, firstTagPredicate);
-        FindCommand findSixthCommand = new FindCommand(secondPredicate, secondTagPredicate);
+        FindCommand findFifthCommand = new FindCommand(firstPredicate,
+                firstTagPredicate, returnTruePredicate);
+        FindCommand findSixthCommand = new FindCommand(secondPredicate,
+                secondTagPredicate, returnTruePredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
@@ -61,13 +68,16 @@ public class FindCommandTest {
         assertTrue(findFifthCommand.equals(findFifthCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, returnTruePredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate,
+                returnTruePredicate, returnTruePredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
-        FindCommand findFourthCommandCopy = new FindCommand(returnTruePredicate, secondTagPredicate);
+        FindCommand findFourthCommandCopy = new FindCommand(returnTruePredicate,
+                secondTagPredicate, returnTruePredicate);
         assertTrue(findFourthCommand.equals(findFourthCommandCopy));
 
-        FindCommand findSixthCommandCopy = new FindCommand(secondPredicate, secondTagPredicate);
+        FindCommand findSixthCommandCopy = new FindCommand(secondPredicate,
+                secondTagPredicate, returnTruePredicate);
         assertTrue(findSixthCommand.equals(findSixthCommandCopy));
 
         // different types -> returns false
@@ -89,9 +99,10 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         PersonTagContainsKeywordsPredicate tagPredicate = prepareTagPredicate(" ");
-        FindCommand command = new FindCommand(predicate, tagPredicate);
+        AddressContainsKeywordsPredicate addressPredicate = prepareAddressPredicate(" ");
+        FindCommand command = new FindCommand(predicate, tagPredicate, addressPredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -100,8 +111,8 @@ public class FindCommandTest {
     @Test
     public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate, returnTruePredicate);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
+        FindCommand command = new FindCommand(predicate, returnTruePredicate, returnTruePredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
@@ -113,7 +124,7 @@ public class FindCommandTest {
         expectedModel.addPerson(BOB);
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
         PersonTagContainsKeywordsPredicate predicate = prepareTagPredicate("friends husband");
-        FindCommand command = new FindCommand(returnTruePredicate, predicate);
+        FindCommand command = new FindCommand(returnTruePredicate, predicate, returnTruePredicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BENSON, DANIEL, BOB), model.getFilteredPersonList());
@@ -124,9 +135,9 @@ public class FindCommandTest {
         model.addPerson(BOB);
         expectedModel.addPerson(BOB);
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameContainsKeywordsPredicate namePredicate = preparePredicate("Pauline Elle Choo");
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Pauline Elle Choo");
         PersonTagContainsKeywordsPredicate tagPredicate = prepareTagPredicate("friends husband");
-        FindCommand command = new FindCommand(namePredicate, tagPredicate);
+        FindCommand command = new FindCommand(namePredicate, tagPredicate, returnTruePredicate);
         expectedModel.updateFilteredPersonList(namePredicate.and(tagPredicate));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BOB), model.getFilteredPersonList());
@@ -135,7 +146,7 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
@@ -144,5 +155,12 @@ public class FindCommandTest {
      */
     private PersonTagContainsKeywordsPredicate prepareTagPredicate(String userInput) {
         return new PersonTagContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code AddressContainsKeywordsPredicate}.
+     */
+    private AddressContainsKeywordsPredicate prepareAddressPredicate(String userInput) {
+        return new AddressContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -28,6 +29,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.Blacklist;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -89,12 +91,15 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
         List<String> tagKeywords = Arrays.asList("tagOne", "tagTwo");
+        List<String> addressKeywords = Arrays.asList("address1", "address2");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " "
                         + PREFIX_NAME + nameKeywords.stream().collect(Collectors.joining(" ")) + " "
-                        + PREFIX_TAG + tagKeywords.stream().collect(Collectors.joining(" ")));
+                        + PREFIX_TAG + tagKeywords.stream().collect(Collectors.joining(" ")) + " "
+                        + PREFIX_ADDRESS + addressKeywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(nameKeywords),
-                new PersonTagContainsKeywordsPredicate(tagKeywords)),
+                        new PersonTagContainsKeywordsPredicate(tagKeywords),
+                        new AddressContainsKeywordsPredicate(addressKeywords)),
                 command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -29,7 +29,8 @@ public class FindCommandParserTest {
     public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")), returnTruePredicate);
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        returnTruePredicate, returnTruePredicate);
         assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
@@ -40,7 +41,8 @@ public class FindCommandParserTest {
     public void parse_validTagArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =
                 new FindCommand(returnTruePredicate,
-                        new PersonTagContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                        new PersonTagContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        returnTruePredicate);
         assertParseSuccess(parser, " " + PREFIX_TAG + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
@@ -51,7 +53,8 @@ public class FindCommandParserTest {
     public void parse_validNameAndTagArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
-                        new PersonTagContainsKeywordsPredicate(Arrays.asList("tagOne", "tagTwo")));
+                        new PersonTagContainsKeywordsPredicate(Arrays.asList("tagOne", "tagTwo")),
+                        returnTruePredicate);
         assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob " + PREFIX_TAG + "tagOne tagTwo",
                 expectedFindCommand);
 


### PR DESCRIPTION
Fixes #62.

Process is rather similar to #23. `AddressContainKeywordsPredicate` is included to support the implementation of this feature.

While JUnit tests are updated due to changes made to the constructor in `FindCommand` class, more JUnit tests will be included in v1.4 instead.